### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,10 +1,10 @@
-SPort  KEYWORD1
+SPort	KEYWORD1
 
-begin KEYWORD2
-process KEYWORD2
-getVarioSpeed  KEYWORD2
-getVarioAltitude  KEYWORD2
-getFailsafeStatus KEYWORD2
-getVfasVoltage  KEYWORD2
-getVfasCurrent KEYWORD2
-getVfasConsumption KEYWORD2
+begin	KEYWORD2
+process	KEYWORD2
+getVarioSpeed	KEYWORD2
+getVarioAltitude	KEYWORD2
+getFailsafeStatus	KEYWORD2
+getVfasVoltage	KEYWORD2
+getVfasCurrent	KEYWORD2
+getVfasConsumption	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords